### PR TITLE
Allow an 'excluded' argument to skip certain file patterns from sync

### DIFF
--- a/ampy/file_sync.py
+++ b/ampy/file_sync.py
@@ -156,25 +156,25 @@ def get_sync_info(pc_info, dev_info):
     return sync_info
 
 def should_exclude(name, excluded):
-  name = name.lower()
-  for exclusion in excluded:
-    exclusion = exclusion.lower()
-    if exclusion.startswith("*") and exclusion.endswith("*"):
-      match_type = "IN"
-    elif exclusion.startswith("*"):
-      match_type = "END"
-    elif exclusion.endswith("*"):
-      match_type = "START"
-    else: 
-      match_type = "EXACT"
-    raw_exclusion = exclusion.replace("*","")
-    if ((match_type == "IN" and raw_exclusion in name)
-    or (match_type == "END" and name.endswith(raw_exclusion))
-    or (match_type == "START" and name.startswith(raw_exclusion))
-    or (match_type == "EXACT" and name == raw_exclusion)):
-        print(f"File {name} skipped due to matching {exclusion}")
-        return True
-  return False
+    name = name.lower()
+    for exclusion in excluded:
+        exclusion = exclusion.lower()
+        if exclusion.startswith("*") and exclusion.endswith("*"):
+            match_type = "IN"
+        elif exclusion.startswith("*"):
+            match_type = "END"
+        elif exclusion.endswith("*"):
+            match_type = "START"
+        else: 
+            match_type = "EXACT"
+        raw_exclusion = exclusion.replace("*","")
+        if ((match_type == "IN" and raw_exclusion in name)
+        or (match_type == "END" and name.endswith(raw_exclusion))
+        or (match_type == "START" and name.startswith(raw_exclusion))
+        or (match_type == "EXACT" and name == raw_exclusion)):
+            print(f"File {name} skipped due to matching {exclusion}")
+            return True
+    return False
 
 
 def file_sync_info(local_path, info_pathname, excluded, rtt_version):

--- a/cli.py
+++ b/cli.py
@@ -42,6 +42,7 @@ import json
 import ampy.files as files
 import ampy.pyboard as pyboard
 import gc
+import ast
 
 from ampy.getch import getch
 from ampy.file_sync import file_sync_info
@@ -677,7 +678,18 @@ def repl(query = None):
     metavar="query",
 )
 
-def sync(local_path, file_pathname, remote_path = None, info_pathname = None, query = None):
+@click.option(
+    "--excluded",
+    "-x",
+    envvar="excluded",
+    # required=True,
+    default=None,
+    type=click.STRING,
+    help="An array-like string of file patterns to be excluded. Supports asterisk (*) wildcards at start or end of pattern",
+    metavar="excluded",
+)
+
+def sync(local_path, file_pathname, remote_path = None, info_pathname = None, query = None, excluded = None):
     def _sync_file(sync_info, local, remote = None):
         local = local.replace('\\', '/')
         delete_file_list = sync_info["delete"]
@@ -759,7 +771,8 @@ def sync(local_path, file_pathname, remote_path = None, info_pathname = None, qu
         board_files._ls_sync(long_format=True, recursive=True, pathname = info_pathname)
 
     # Gets file synchronization information
-    sync_info, pc_file_info = file_sync_info(local_path, info_pathname, rtt_version_flag)
+    excluded = ast.literal_eval(excluded) if excluded else []
+    sync_info, pc_file_info = file_sync_info(local_path, info_pathname, excluded, rtt_version_flag)
 
     # print("sync_info------------------------------")
     # print(sync_info)


### PR DESCRIPTION
Currently, `.git` and IDE folders (`.vscode`, `.idea` etc) are included in syncing. Some of these folders have led to the synced device getting into state where future syncs fail

I have added the ability to pass in an `--excluded` / `-x` parameter to be added so that these kind of files can be ignored.

e.g.
`python cli.py -p com18 sync -l "G:\sync_dir" -i "G:\file_list_cache" -x ['.git*','.vscode*']`

These files will be ignored when syncing.
Asterisk `*` wildcards at the beginning and end of the string are supported


目前，做同步时同步的文件包括 'git' 和 IDE （`.vscode`, `.idea` 等）文件夹。这种文件夹会在目标设备上造成问题，然后后来的同步失败。

我贯彻了能收入`--excluded`/`-x` (排斥) 参数的功能。因此，可以排斥这种文件。

例如：
`python cli.py -p com18 sync -l "G:\sync_dir" -i "G:\file_list_cache" -x ['.git*','.vscode*']`

同步的时候不考虑这些文件。

可以在字符串前后面加星号(*)通配符。